### PR TITLE
[Chore] JitpackからGitHub Packagesへ公開設定を変更

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,34 @@
+name: Publish to GitHub Packages
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: macos-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Publish to GitHub Packages
+        run: ./gradlew publish
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
@@ -2,6 +2,9 @@ import io.github.kei_1111.newsflow.library.libs
 import io.github.kei_1111.newsflow.library.versions
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.repositories
 
 class MavenPublishConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -12,6 +15,21 @@ class MavenPublishConventionPlugin : Plugin<Project> {
 
             group = "io.github.kei-1111.newsflow.library"
             version = libs.versions("newsflowLibrary")
+
+            afterEvaluate {
+                extensions.configure<PublishingExtension> {
+                    repositories {
+                        maven {
+                            name = "GitHubPackages"
+                            url = uri("https://maven.pkg.github.com/kei-1111/newsflow-library")
+                            credentials {
+                                username = System.getenv("GITHUB_ACTOR") ?: project.findProperty("gpr.user") as String?
+                                password = System.getenv("GITHUB_TOKEN") ?: project.findProperty("gpr.token") as String?
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,0 @@
-jdk:
-  - openjdk21
-
-install:
-  - ./gradlew publishToMavenLocal


### PR DESCRIPTION
## 概要 / Overview

JitPackからGitHub Packagesへ公開方法を変更し、タグプッシュ時に自動公開するワークフローを追加

## 変更内容 / Changes

- MavenPublishConventionPluginにGitHub Packages設定を追加
- android-release.ymlワークフローを追加（タグプッシュ時に公開）
- jitpack.ymlを削除

## テスト / Testing

- [x] ビルドが成功 / Build succeeds

## チェックリスト / Checklist

- [x] コードは命名規則に従っている / Code follows naming conventions